### PR TITLE
Support Non-repository Logging

### DIFF
--- a/asv/repo.py
+++ b/asv/repo.py
@@ -89,7 +89,7 @@ class Repo(object):
 
     def get_new_range_spec(self, latest_result, branch=None):
         """
-        Returns a formatted string giving the results between the 
+        Returns a formatted string giving the results between the
         latest result and the newest hash in a given branch.
         If no branch given, use the 'master' branch.
         """


### PR DESCRIPTION
Adds support for logging without a standard version-controlled repository,
which is the case for our current Docker testing setup.

To run ASV, `asv run --show-stderr --python=same --force-record-commit [COMMIT_ID]`.
Specifically `asv run ... $(cat ../git-rev)`, in `$RAY_DIR/python`.

To automate, you may want to run `asv machine --yes` first.